### PR TITLE
fix raw block missing in the output or crashing the program

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -135,11 +135,11 @@ fn mutilate<W: Write>(
         }
         SyntaxKind::Raw => {
             let raw: ast::Raw = syntax.cast().unwrap();
-            let backticks = syntax.text().split(|c| c != '`').next().unwrap();
+            let raw_text = syntax.clone().into_text();
+            let backticks = raw_text.split(|c| c != '`').next().unwrap();
             write!(output, "{backticks}")?;
 
-            let mut text = syntax
-                .text()
+            let mut text = raw_text
                 .trim_start_matches('`')
                 .strip_suffix(backticks)
                 .unwrap();


### PR DESCRIPTION
It seems like running `typst-mutilate` against my document would crash it, upon some debugging I updated the handling of raw blocks.

The original code calls `text()` on a `SyntaxNode`, which "Returns the empty string if this is an inner node". Maybe this was a change from typst 0.11 ?

With this fix, the raw blocks should be scrambled without crashing `typst-mutilate`.

Please tell me if there's something to be improved !